### PR TITLE
Update gmail link to default in google.com page

### DIFF
--- a/data/gapps-info.js
+++ b/data/gapps-info.js
@@ -12,7 +12,7 @@ var gapps_info = {
     "iconpos" : "0px -1863px"
   },
   "gmail": {
-    "url" : "https://gmail.com/",
+    "url" : "https://mail.google.com/",
     "desc" : "Gmail",
     "iconpos" : "0px -966px"
   },


### PR DESCRIPTION
In https://www.google.com the link to Gmail is https://mail.google.com/ .
Some companies block the https://gmail.com/ and allowed only https://mail.google.com/

Your addon is Great! Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/asolkar/ffx-addon-gglappbtn/15)
<!-- Reviewable:end -->
